### PR TITLE
Unit test enhancements

### DIFF
--- a/Sources/JSON/JSON+Equatable.swift
+++ b/Sources/JSON/JSON+Equatable.swift
@@ -1,5 +1,0 @@
-//extension JSON: Equatable {
-//    public static func ==(lhs: JSON, rhs: JSON) -> Bool {
-//        return lhs.sche == rhs.node
-//    }
-//}

--- a/Tests/JSONTests/JSONConvertibleTests.swift
+++ b/Tests/JSONTests/JSONConvertibleTests.swift
@@ -100,11 +100,11 @@ class JSONConvertibleTests: XCTestCase {
 
     func testJSONSequence() throws {
         let personOne = Person(name: "John", age: 24)
-        let personTwo = Person(name: "Louie", age: 25)
+        let personTwo = Person(name: "Louie", age: 44)
         let persons = [personOne, personTwo]
         let json = try persons.makeJSON()
         
-        let expectedString = "[{\"name\":\"John\",\"age\":24},{\"name\":\"Louie\",\"age\":25}]"
+        let expectedString = "[{\"name\":\"John\",\"age\":24},{\"name\":\"Louie\",\"age\":44}]"
         let expectedJSON = try JSON(bytes: expectedString)
         
         XCTAssertEqual(json, expectedJSON)

--- a/Tests/JSONTests/JSONConvertibleTests.swift
+++ b/Tests/JSONTests/JSONConvertibleTests.swift
@@ -40,7 +40,8 @@ class JSONConvertibleTests: XCTestCase {
         ("testJSONRepresentable", testJSONRepresentable),
         ("testSequenceJSONRepresentable", testSequenceJSONRepresentable),
         ("testSetters", testSetters),
-        ("testGetters", testGetters)
+        ("testGetters", testGetters),
+        ("testJSONSequence", testJSONSequence)
     ]
     
     override func setUp() {
@@ -97,4 +98,15 @@ class JSONConvertibleTests: XCTestCase {
         }
     }
 
+    func testJSONSequence() throws {
+        let personOne = Person(name: "John", age: 24)
+        let personTwo = Person(name: "Louie", age: 25)
+        let persons = [personOne, personTwo]
+        let json = try persons.makeJSON()
+        
+        let expectedString = "[{\"name\":\"John\",\"age\":24},{\"name\":\"Louie\",\"age\":25}]"
+        let expectedJSON = try JSON(bytes: expectedString)
+        
+        XCTAssertEqual(json, expectedJSON)
+    }
 }

--- a/Tests/JSONTests/JSONConvertibleTests.swift
+++ b/Tests/JSONTests/JSONConvertibleTests.swift
@@ -38,7 +38,9 @@ class JSONConvertibleTests: XCTestCase {
     static let allTests = [
         ("testJSONInitializable", testJSONInitializable),
         ("testJSONRepresentable", testJSONRepresentable),
-        ("testSequenceJSONRepresentable", testSequenceJSONRepresentable)
+        ("testSequenceJSONRepresentable", testSequenceJSONRepresentable),
+        ("testSetters", testSetters),
+        ("testGetters", testGetters)
     ]
     
     override func setUp() {

--- a/Tests/JSONTests/JSONTests.swift
+++ b/Tests/JSONTests/JSONTests.swift
@@ -60,7 +60,7 @@ class JSONTests: XCTestCase {
         let json = JSON(node:
             .object(
                 [
-                    "hello": "world"
+                    "hello" : "world"
                 ]
             )
         )

--- a/Tests/JSONTests/JSONTests.swift
+++ b/Tests/JSONTests/JSONTests.swift
@@ -60,11 +60,11 @@ class JSONTests: XCTestCase {
         let json = JSON(node:
             .object(
                 [
-                    "hello" : "world"
+                    "hello": "world"
                 ]
             )
         )
-        
+
         let serialized = try json.serialize(prettyPrint: true).makeString()
         // JSONSerialization.data(withJSONObject: _, options: .prettyPrinted)
         // results in different spacing in OSX/Linux

--- a/Tests/JSONTests/JSONTests.swift
+++ b/Tests/JSONTests/JSONTests.swift
@@ -68,7 +68,6 @@ class JSONTests: XCTestCase {
         let serialized = try json.serialize(prettyPrint: true).makeString()
         // JSONSerialization.data(withJSONObject: _, options: .prettyPrinted)
         // results in different spacing in OSX/Linux
-        )
         #if os(Linux)
             let expectation = "{\n  \"hello\": \"world\"\n}"
         #else

--- a/Tests/JSONTests/JSONTests.swift
+++ b/Tests/JSONTests/JSONTests.swift
@@ -64,9 +64,16 @@ class JSONTests: XCTestCase {
                 ]
             )
         )
-
+        
         let serialized = try json.serialize(prettyPrint: true).makeString()
-        let expectation = "{\n  \"hello\" : \"world\"\n}"
+        // JSONSerialization.data(withJSONObject: _, options: .prettyPrinted)
+        // results in different spacing in OSX/Linux
+        )
+        #if os(Linux)
+            let expectation = "{\n  \"hello\": \"world\"\n}"
+        #else
+            let expectation = "{\n  \"hello\" : \"world\"\n}"
+        #endif
         XCTAssertEqual(serialized, expectation)
     }
 

--- a/Tests/JSONTests/JSONTests.swift
+++ b/Tests/JSONTests/JSONTests.swift
@@ -8,6 +8,8 @@ class JSONTests: XCTestCase {
     static let allTests = [
         ("testParse", testParse),
         ("testSerialize", testSerialize),
+        ("testPrettySerialize", testPrettySerialize),
+        ("testStringEscaping", testStringEscaping),
         ("testSerializePerformance", testSerializePerformance),
         ("testParsePerformance", testParsePerformance),
         ("testMultiThread", testMultiThread),


### PR DESCRIPTION
- Primary goal was to have all unit tests in the `allTests` property in both `XCTestCase` subclasses.
- Removed `JSON+Equatable.swift`.  This is not needed because `JSON` implements the `StructuredDataWrapper` which is equatable.
- Added test case for a JSONRepresentable Sequence.